### PR TITLE
Accept lists as vardaic command arguments

### DIFF
--- a/shell-conduit.cabal
+++ b/shell-conduit.cabal
@@ -1,5 +1,5 @@
 name:                shell-conduit
-version:             4.5.1
+version:             4.6.0
 synopsis:            Write shell scripts with Conduit
 description:         Write shell scripts with Conduit. See "Data.Conduit.Shell" for documentation.
 license:             BSD3

--- a/src/Data/Conduit/Shell/PATH.hs
+++ b/src/Data/Conduit/Shell/PATH.hs
@@ -19,6 +19,8 @@ import           System.Directory
 
 -- | Helpful CD command.
 cd :: (MonadIO m,CmdArg arg) => arg -> m ()
-cd fp = liftIO (setCurrentDirectory (T.unpack (toTextArg fp)))
+cd = liftIO . setCurrentDirectory . T.unpack . toTextArg
 
 $(generateBinaries)
+
+


### PR DESCRIPTION
I often have to call programs with variable length argument list, and with
previous interface it rendered useless whole TH module, and I had to
fallback on `proc` function, which, btw, makes `haskell-mode` insane.

 * make possible `run $ mkdir "-p" ["foo", "bar"]`
 * version bump