### PR TITLE
Fixes for ghc7.10rc1

### DIFF
--- a/src/Data/Conduit/Shell/Process.hs
+++ b/src/Data/Conduit/Shell/Process.hs
@@ -44,7 +44,7 @@ import           Data.Typeable
 import           System.Exit
 import           System.IO
 import           System.Posix.IO (createPipe, fdToHandle)
-import           System.Process
+import           System.Process hiding (createPipe)
 import           System.Process.Internals (createProcess_)
 
 -- | A pipeable segment. Either a conduit or a process.

--- a/src/Data/Conduit/Shell/TH.hs
+++ b/src/Data/Conduit/Shell/TH.hs
@@ -57,7 +57,7 @@ getUniqueName candidate =
   do inScope <- recover (return False)
                         (do void (reify (mkName candidate))
                             return True)
-     if inScope
+     if inScope || candidate == "import"
         then getUniqueName (candidate ++ "'")
         else return (mkName candidate)
 


### PR DESCRIPTION
One fix is 7.10 related (or just newer dependencies?).

The other is a placeholder fix and should be better generalized: presence of the "import" binary from linux package imagemagick will cause a TH error at compile time. I'm sure there are plenty other names that should be mangled, but I didn't attempt to find them all. I also wasn't sure how/where to best handle the check.